### PR TITLE
Add Google Oauth flow intergration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,8 @@
         "php": "^7.4|^8.0",
         "google/apiclient": "^2.7",
         "skagarwal/google-places-api": "^1.7",
+        "spatie/data-transfer-object": "^2.8",
+        "spatie/valuestore": "^1.2",
         "tipoff/authorization": "^2.8.0",
         "tipoff/support": "^2.0.0"
     },
@@ -52,7 +54,10 @@
         "laravel": {
             "providers": [
                 "Tipoff\\GoogleApi\\GoogleApiServiceProvider"
-            ]
+            ],
+            "aliases": {
+                "GoogleOauth": "Tipoff\\GoogleApi\\Facades\\GoogleOauth"
+            }
         }
     },
     "repositories": [

--- a/config/google-api.php
+++ b/config/google-api.php
@@ -1,77 +1,13 @@
 <?php
 
 return [
-    'my-business' => [
-        'client-secret' => [
-            "web" => [
-                "client_id" => env('GOOGLE_MYBUSINESS_CLIENT_ID') ?? env('GOOGLE_CLIENT_ID'),
-                "project_id" => env('GOOGLE_MYBUSINESS_PROJECT_ID') ?? env('GOOGLE_PROJECT_ID'),
-                "auth_uri" => env('GOOGLE_MYBUSINESS_AUTH_URI', env('GOOGLE_AUTH_URI', 'https://accounts.google.com/o/oauth2/auth')),
-                "token_uri" => env('GOOGLE_MYBUSINESS_TOKEN_URI', env('GOOGLE_TOKEN_URI', 'https://oauth2.googleapis.com/token')),
-                "auth_provider_x509_cert_url" => env('GOOGLE_MYBUSINESS_CERT_URL', env('GOOGLE_CERT_URL', 'https://www.googleapis.com/oauth2/v1/certs')),
-                "client_secret" => env('GOOGLE_MYBUSINESS_CLIENT_SECRET') ?? env('GOOGLE_CLIENT_SECRET'),
-                "redirect_uris" => explode('|', env('GOOGLE_MYBUSINESS_REDIRECT_URIS') ?? env('GOOGLE_REDIRECT_URIS', '')),
-                "javascript_origins" => explode('|', env('GOOGLE_MYBUSINESS_JAVASCRIPT_ORIGINS') ?? env('GOOGLE_JAVASCRIPT_ORIGINS', '')),
-                "scopes" => explode('|', env('GOOGLE_MYBUSINESS_SCOPES') ?? env('GOOGLE_SCOPES', 'https://www.googleapis.com/auth/business.manage')),
-            ],
-        ],
-        'access-token-slug' => env('GOOGLE_MYBUSINESS_ACCESS_TOKEN_SLUG', env('GOOGLE_ACCESS_TOKEN_SLUG', 'gmb-token')),
-    ],
+    'project_id' => env('GOOGLE_PROJECT_ID'),
 
-    'youtube' => [
-        'client-secret' => [
-            "web" => [
-                "client_id" => env('YOUTUBE_CLIENT_ID') ?? env('GOOGLE_CLIENT_ID'),
-                "project_id" => env('YOUTUBE_PROJECT_ID') ?? env('GOOGLE_PROJECT_ID'),
-                "auth_uri" => env('YOUTUBE_AUTH_URI', env('GOOGLE_AUTH_URI', 'https://accounts.google.com/o/oauth2/auth')),
-                "token_uri" => env('YOUTUBE_TOKEN_URI', env('GOOGLE_TOKEN_URI', 'https://oauth2.googleapis.com/token')),
-                "auth_provider_x509_cert_url" => env('YOUTUBE_CERT_URL', env('GOOGLE_CERT_URL', 'https://www.googleapis.com/oauth2/v1/certs')),
-                "client_secret" => env('YOUTUBE_CLIENT_SECRET') ?? env('GOOGLE_CLIENT_SECRET'),
-                "redirect_uris" => explode('|', env('YOUTUBE_REDIRECT_URIS') ?? env('GOOGLE_REDIRECT_URIS', '')),
-                "javascript_origins" => explode('|', env('YOUTUBE_JAVASCRIPT_ORIGINS') ?? env('GOOGLE_JAVASCRIPT_ORIGINS', '')),
-                "scopes" => explode('|', env('YOUTUBE_SCOPES') ?? env('GOOGLE_SCOPES', '')),
-            ],
-        ],
-        'access-token-slug' => env('YOUTUBE_ACCESS_TOKEN_SLUG', env('GOOGLE_ACCESS_TOKEN_SLUG', 'youtube-token')),
-    ],
+    'client_id' => env('GOOGLE_CLIENT_ID'),
 
-    'youtube-analytics' => [
-        'client-secret' => [
-            "web" => [
-                "client_id" => env('YOUTUBE_ANALYTICS_CLIENT_ID') ?? env('GOOGLE_CLIENT_ID'),
-                "project_id" => env('YOUTUBE_ANALYTICS_PROJECT_ID') ?? env('GOOGLE_PROJECT_ID'),
-                "auth_uri" => env('YOUTUBE_ANALYTICS_AUTH_URI', env('GOOGLE_AUTH_URI', 'https://accounts.google.com/o/oauth2/auth')),
-                "token_uri" => env('YOUTUBE_ANALYTICS_TOKEN_URI', env('GOOGLE_TOKEN_URI', 'https://oauth2.googleapis.com/token')),
-                "auth_provider_x509_cert_url" => env('YOUTUBE_ANALYTICS_CERT_URL', env('GOOGLE_CERT_URL', 'https://www.googleapis.com/oauth2/v1/certs')),
-                "client_secret" => env('YOUTUBE_ANALYTICS_CLIENT_SECRET') ?? env('GOOGLE_CLIENT_SECRET'),
-                "redirect_uris" => explode('|', env('YOUTUBE_ANALYTICS_REDIRECT_URIS') ?? env('GOOGLE_REDIRECT_URIS', '')),
-                "javascript_origins" => explode('|', env('YOUTUBE_ANALYTICS_JAVASCRIPT_ORIGINS') ?? env('GOOGLE_JAVASCRIPT_ORIGINS', '')),
-                "scopes" => explode('|', env('YOUTUBE_ANALYTICS_SCOPES') ?? env('GOOGLE_SCOPES', '')),
-            ],
-        ],
-        'access-token-slug' => env('YOUTUBE_ANALYTICS_ACCESS_TOKEN_SLUG', env('GOOGLE_ACCESS_TOKEN_SLUG', 'youtube-analytics-token')),
-    ],
+    'client_secret' => env('GOOGLE_CLIENT_SECRET'),
 
-    'analytics' => [
-        'client-secret' => [
-            "web" => [
-                "client_id" => env('ANALYTICS_CLIENT_ID') ?? env('GOOGLE_CLIENT_ID'),
-                "project_id" => env('ANALYTICS_PROJECT_ID') ?? env('GOOGLE_PROJECT_ID'),
-                "auth_uri" => env('ANALYTICS_AUTH_URI', env('GOOGLE_AUTH_URI', 'https://accounts.google.com/o/oauth2/auth')),
-                "token_uri" => env('ANALYTICS_TOKEN_URI', env('GOOGLE_TOKEN_URI', 'https://oauth2.googleapis.com/token')),
-                "auth_provider_x509_cert_url" => env('ANALYTICS_CERT_URL', env('GOOGLE_CERT_URL', 'https://www.googleapis.com/oauth2/v1/certs')),
-                "client_secret" => env('ANALYTICS_CLIENT_SECRET') ?? env('GOOGLE_CLIENT_SECRET'),
-                "redirect_uris" => explode('|', env('ANALYTICS_REDIRECT_URIS') ?? env('GOOGLE_REDIRECT_URIS', '')),
-                "javascript_origins" => explode('|', env('ANALYTICS_JAVASCRIPT_ORIGINS') ?? env('GOOGLE_JAVASCRIPT_ORIGINS', '')),
-                "scopes" => explode('|', env('ANALYTICS_SCOPES') ?? env('GOOGLE_SCOPES', '')),
-            ],
-        ],
-        'access-token-slug' => env('ANALYTICS_ACCESS_TOKEN_SLUG', env('GOOGLE_ACCESS_TOKEN_SLUG', 'analytics-token')),
-    ],
+    'redirect_uri' => env('GOOGLE_REDIRECT_URI', '/'),
 
-    'places' => [
-        'key' => env('GOOGLE_PLACES_API_KEY', env('GOOGLE_API_KEY', null)),
-        'verify_ssl' => env('GOOGLE_PLACES_VERIFY_SSL', true),
-        'headers' => env('GOOGLE_PLACES_HEADERS', []),
-    ],
+    'state' => null,
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Tipoff\GoogleApi\Http\Controllers\GoogleOauthController;
+
+Route::middleware(config('tipoff.web.middleware_group'))
+    ->prefix(config('tipoff.web.uri_prefix'))
+    ->group(function () {
+
+        Route::prefix('google-oauth')
+            ->group(function () {
+            Route::get('oauth', [GoogleOauthController::class, 'redirect'])->name('google-oauth.connect');
+            Route::get('callback', [GoogleOauthController::class, 'handleCallback'])->name('google-oauth.callback');
+            Route::get('logout', [GoogleOauthController::class, 'logout'])->name('google-oauth.logout');
+        });
+    });

--- a/src/Contracts/GoogleOauthDriver.php
+++ b/src/Contracts/GoogleOauthDriver.php
@@ -1,0 +1,12 @@
+<?php namespace Tipoff\GoogleApi\Contracts;
+
+use Tipoff\GoogleApi\DataTransferObjects\AccessToken;
+
+interface GoogleOauthDriver
+{
+    public function readAccessToken($identifier): AccessToken;
+
+    public function flushAccessToken($identifier);
+
+    public function saveAccessToken($identifier, array $accessToken);
+}

--- a/src/DataTransferObjects/AccessToken.php
+++ b/src/DataTransferObjects/AccessToken.php
@@ -1,0 +1,50 @@
+<?php namespace Tipoff\GoogleApi\DataTransferObjects;
+
+use Spatie\DataTransferObject\FlexibleDataTransferObject;
+
+class AccessToken extends FlexibleDataTransferObject
+{
+    public string $access_token;
+
+    public int $expires_in;
+
+    public string $scope;
+
+    public string $token_type;
+
+    public int $created;
+
+    public string $refresh_token;
+
+    /**
+     * @return string
+     */
+    public function getAccessToken()
+    {
+        return $this->access_token;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRefreshToken()
+    {
+        return $this->refresh_token;
+    }
+
+    /**
+     * @return int
+     */
+    public function getExpires()
+    {
+        return $this->expires_in;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasExpired()
+    {
+        return $this->getExpires() < time();
+    }
+}

--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -1,0 +1,42 @@
+<?php namespace Tipoff\GoogleApi\Drivers;
+
+use Spatie\Valuestore\Valuestore;
+use Tipoff\GoogleApi\Contracts\GoogleOauthDriver;
+use Tipoff\GoogleApi\DataTransferObjects\AccessToken;
+
+class JsonDriver implements GoogleOauthDriver
+{
+    protected ?Valuestore $valuestore = null;
+
+    public function readAccessToken($identifier): AccessToken
+    {
+        $accessToken = $this->valueStore($identifier)->all();
+
+        if (!count($accessToken)) {
+            throw new \Exception('Cannot not read access token with identifier ' . $identifier);
+        }
+
+        return new AccessToken($accessToken);
+    }
+
+    public function flushAccessToken($identifier)
+    {
+        $this->valueStore($identifier)->flush();
+    }
+
+    public function saveAccessToken($identifier, array $accessToken)
+    {
+        $this->valueStore($identifier)->flush();
+
+        $this->valueStore($identifier)->put($accessToken);
+    }
+
+    private function valueStore($identifier)
+    {
+        if (is_null($this->valuestore)) {
+            $this->valuestore = Valuestore::make(storage_path('app/google-oauth/' . $identifier . '.json'));
+        }
+
+        return $this->valuestore;
+    }
+}

--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -12,7 +12,7 @@ class JsonDriver implements GoogleOauthDriver
     {
         $accessToken = $this->valueStore($identifier)->all();
 
-        if (!count($accessToken)) {
+        if (! count($accessToken)) {
             throw new \Exception('Cannot not read access token with identifier ' . $identifier);
         }
 

--- a/src/Drivers/KeyEloquentDriver.php
+++ b/src/Drivers/KeyEloquentDriver.php
@@ -13,7 +13,7 @@ class KeyEloquentDriver implements GoogleOauthDriver
 
         $accessToken = optional($model)->value;
 
-        if (!$accessToken) {
+        if (! $accessToken) {
             throw new \Exception('Cannot not read access token with identifier ' . $identifier);
         }
 
@@ -30,7 +30,7 @@ class KeyEloquentDriver implements GoogleOauthDriver
         Key::updateOrCreate(
             ['slug' => $identifier],
             [
-                'value'      => $accessToken,
+                'value' => $accessToken,
                 'creator_id' => Auth::id(),
                 'updater_id' => Auth::id(),
             ]

--- a/src/Drivers/KeyEloquentDriver.php
+++ b/src/Drivers/KeyEloquentDriver.php
@@ -1,0 +1,39 @@
+<?php namespace Tipoff\GoogleApi\Drivers;
+
+use Illuminate\Support\Facades\Auth;
+use Tipoff\GoogleApi\Contracts\GoogleOauthDriver;
+use Tipoff\GoogleApi\DataTransferObjects\AccessToken;
+use Tipoff\GoogleApi\Models\Key;
+
+class KeyEloquentDriver implements GoogleOauthDriver
+{
+    public function readAccessToken($identifier): AccessToken
+    {
+        $model = Key::where('slug', $identifier)->first();
+
+        $accessToken = optional($model)->value;
+
+        if (!$accessToken) {
+            throw new \Exception('Cannot not read access token with identifier ' . $identifier);
+        }
+
+        return new AccessToken($accessToken);
+    }
+
+    public function flushAccessToken($identifier)
+    {
+        Key::where('slug', $identifier)->delete();
+    }
+
+    public function saveAccessToken($identifier, array $accessToken)
+    {
+        Key::updateOrCreate(
+            ['slug' => $identifier],
+            [
+                'value'      => $accessToken,
+                'creator_id' => Auth::id(),
+                'updater_id' => Auth::id(),
+            ]
+        );
+    }
+}

--- a/src/Facades/GoogleOauth.php
+++ b/src/Facades/GoogleOauth.php
@@ -1,0 +1,28 @@
+<?php namespace Tipoff\GoogleApi\Facades;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Facade;
+use Tipoff\GoogleApi\DataTransferObjects\AccessToken;
+
+/**
+ * @see \Tipoff\GoogleApi\GoogleAuth
+ *
+ * @method static $this setIdentifier(string $identifier)
+ * @method static $this setScopes(array $scopes)
+ * @method static AccessToken accessToken($identifier = null)
+ * @method static AccessToken makeAccessToken()
+ * @method static AccessToken refreshAccessToken($refreshToken = null)
+ * @method static AccessToken readAccessToken()
+ * @method static void flushAccessToken()
+ * @method static RedirectResponse redirect(?string $identifier = null, ?string $homeUrl = '/')
+ * @method static string getAuthUrl()
+ * @method static mixed routes()
+ * @method static void useDriver(string $class)
+ */
+class GoogleOauth extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'google-oauth';
+    }
+}

--- a/src/Facades/GoogleOauth.php
+++ b/src/Facades/GoogleOauth.php
@@ -7,11 +7,11 @@ use Tipoff\GoogleApi\DataTransferObjects\AccessToken;
 /**
  * @see \Tipoff\GoogleApi\GoogleAuth
  *
- * @method static $this setIdentifier(string $identifier)
- * @method static $this setScopes(array $scopes)
- * @method static AccessToken accessToken($identifier = null)
+ * @method static \Tipoff\GoogleApi\GoogleOauth setIdentifier(string $identifier)
+ * @method static \Tipoff\GoogleApi\GoogleOauth setScopes(array $scopes)
+ * @method static AccessToken accessToken(?string $identifier = null)
  * @method static AccessToken makeAccessToken()
- * @method static AccessToken refreshAccessToken($refreshToken = null)
+ * @method static AccessToken refreshAccessToken(?string $refreshToken = null)
  * @method static AccessToken readAccessToken()
  * @method static void flushAccessToken()
  * @method static RedirectResponse redirect(?string $identifier = null, ?string $homeUrl = '/')

--- a/src/GoogleApiServiceProvider.php
+++ b/src/GoogleApiServiceProvider.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Tipoff\GoogleApi;
 
-use Exception;
 use Google_Client;
-use Google_Service_Analytics;
-use Google_Service_MyBusiness;
-use Google_Service_YouTube;
-use Google_Service_YouTubeAnalytics;
-use SKAgarwal\GoogleApi\PlacesApi;
+use Illuminate\Support\Facades\Route;
+use Tipoff\GoogleApi\Contracts\GoogleOauthDriver;
+use Tipoff\GoogleApi\Drivers\JsonDriver;
+use Tipoff\GoogleApi\Http\Controllers\GoogleOauthController;
 use Tipoff\GoogleApi\Models\GmbAccount;
 use Tipoff\GoogleApi\Models\Key;
 use Tipoff\GoogleApi\Policies\GmbAccountPolicy;
@@ -24,7 +22,7 @@ class GoogleApiServiceProvider extends TipoffServiceProvider
     {
         $package
             ->hasPolicies([
-                Key::class => KeyPolicy::class,
+                Key::class        => KeyPolicy::class,
                 GmbAccount::class => GmbAccountPolicy::class,
             ])
             ->hasNovaResources([
@@ -33,75 +31,36 @@ class GoogleApiServiceProvider extends TipoffServiceProvider
             ])
             ->name('google-api')
             ->hasConfigFile('google-api');
+
+        $this->app->bind('google-oauth', function ($app) {
+            return new GoogleOauth(new Google_Client, $app['config']['google-api']);
+        });
     }
-    
+
+    public function packageRegistered()
+    {
+        $this->app->singleton(GoogleOauthDriver::class, JsonDriver::class);
+    }
+
+    public function bootingPackage()
+    {
+        $this->setupGoogleOauthRoutes();
+    }
+
     /**
-     * @psalm-suppress InvalidArgument
+     * Set up routes for Google Oauth process.
      */
-    public function register()
+    private function setupGoogleOauthRoutes()
     {
-        parent::register();
-
-        $this->app->bind(Google_Client::class, function () {
-            return new Google_Client();
+        Route::macro('googleOauth', function ($prefix = 'google-oauth', $middleware = []) {
+            Route::group([
+                'prefix'     => $prefix,
+                'middleware' => $middleware,
+            ], function () {
+                Route::get('oauth', [GoogleOauthController::class, 'redirect'])->name('google-oauth.connect');
+                Route::get('callback', [GoogleOauthController::class, 'handleCallback'])->name('google-oauth.callback');
+                Route::get('logout', [GoogleOauthController::class, 'logout'])->name('google-oauth.logout');
+            });
         });
-
-        $this->app->bind(Google_Service_MyBusiness::class, function () {
-            $client = $this->configureClient(app()->make(Google_Client::class), 'my-business');
-
-            return new Google_Service_MyBusiness($client);
-        });
-
-        $this->app->bind(Google_Service_YouTube::class, function () {
-            $client = $this->configureClient(app()->make(Google_Client::class), 'youtube');
-
-            return new Google_Service_YouTube($client);
-        });
-
-        $this->app->bind(Google_Service_YouTubeAnalytics::class, function () {
-            $client = $this->configureClient(app()->make(Google_Client::class), 'youtube-analytics');
-
-            return new Google_Service_YouTubeAnalytics($client);
-        });
-
-        $this->app->bind(Google_Service_Analytics::class, function () {
-            $client = $this->configureClient(app()->make(Google_Client::class), 'analytics');
-
-            return new Google_Service_Analytics($client);
-        });
-
-        $this->app->bind(PlacesApi::class, function () {
-            return new PlacesApi(
-                config('google-api.places.key'),
-                config('google-api.places.verify_ssl'),
-                config('google-api.places.headers')
-            );
-        });
-    }
-
-    protected function configureClient(Google_Client $client, string $configKey) : Google_Client
-    {
-        if (! config()->has("google-api.$configKey")) {
-            throw new Exception('Invalid Google service configuration specified.');
-        }
-
-        $client->setAuthConfig(config("google-api.$configKey.client-secret"));
-        $client->addScope(config("google-api.$configKey.scopes"));
-        $client->setAccessType('offline');
-
-        $token = json_decode(Key::where('slug', config("google-api.$configKey.access-token-slug"))->firstOrFail()->value, true);
-        $client->setAccessToken($token);
-
-        if ($client->isAccessTokenExpired()) {
-            $client->refreshToken(array_search('refresh_token', $token));
-            $token = $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
-
-            Key::updateOrCreate(
-                ['slug' => config("google-api.$configKey.access-token-slug")],
-                ['value' => json_encode($token)]
-            );
-        }
-        
-        return $client;
     }
 }

--- a/src/GoogleApiServiceProvider.php
+++ b/src/GoogleApiServiceProvider.php
@@ -22,7 +22,7 @@ class GoogleApiServiceProvider extends TipoffServiceProvider
     {
         $package
             ->hasPolicies([
-                Key::class        => KeyPolicy::class,
+                Key::class => KeyPolicy::class,
                 GmbAccount::class => GmbAccountPolicy::class,
             ])
             ->hasNovaResources([
@@ -54,7 +54,7 @@ class GoogleApiServiceProvider extends TipoffServiceProvider
     {
         Route::macro('googleOauth', function ($prefix = 'google-oauth', $middleware = []) {
             Route::group([
-                'prefix'     => $prefix,
+                'prefix' => $prefix,
                 'middleware' => $middleware,
             ], function () {
                 Route::get('oauth', [GoogleOauthController::class, 'redirect'])->name('google-oauth.connect');

--- a/src/GoogleApiServiceProvider.php
+++ b/src/GoogleApiServiceProvider.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Tipoff\GoogleApi;
 
 use Google_Client;
-use Illuminate\Support\Facades\Route;
 use Tipoff\GoogleApi\Contracts\GoogleOauthDriver;
 use Tipoff\GoogleApi\Drivers\JsonDriver;
-use Tipoff\GoogleApi\Http\Controllers\GoogleOauthController;
 use Tipoff\GoogleApi\Models\GmbAccount;
 use Tipoff\GoogleApi\Models\Key;
 use Tipoff\GoogleApi\Policies\GmbAccountPolicy;
@@ -29,38 +27,24 @@ class GoogleApiServiceProvider extends TipoffServiceProvider
                 \Tipoff\GoogleApi\Nova\Key::class,
                 \Tipoff\GoogleApi\Nova\GmbAccount::class,
             ])
+            ->hasWebRoute('web')
             ->name('google-api')
             ->hasConfigFile('google-api');
-
-        $this->app->bind('google-oauth', function ($app) {
-            return new GoogleOauth(new Google_Client, $app['config']['google-api']);
-        });
     }
 
     public function packageRegistered()
     {
+        parent::packageRegistered();
+
         $this->app->singleton(GoogleOauthDriver::class, JsonDriver::class);
     }
 
     public function bootingPackage()
     {
-        $this->setupGoogleOauthRoutes();
-    }
+        parent::bootingPackage();
 
-    /**
-     * Set up routes for Google Oauth process.
-     */
-    private function setupGoogleOauthRoutes()
-    {
-        Route::macro('googleOauth', function ($prefix = 'google-oauth', $middleware = []) {
-            Route::group([
-                'prefix' => $prefix,
-                'middleware' => $middleware,
-            ], function () {
-                Route::get('oauth', [GoogleOauthController::class, 'redirect'])->name('google-oauth.connect');
-                Route::get('callback', [GoogleOauthController::class, 'handleCallback'])->name('google-oauth.callback');
-                Route::get('logout', [GoogleOauthController::class, 'logout'])->name('google-oauth.logout');
-            });
+        $this->app->bind('google-oauth', function ($app) {
+            return new GoogleOauth(new Google_Client, $app['config']['google-api']);
         });
     }
 }

--- a/src/GoogleOauth.php
+++ b/src/GoogleOauth.php
@@ -52,7 +52,7 @@ class GoogleOauth
     public function accessToken($identifier = null): AccessToken
     {
         // Set identifier on the fly.
-        if (!is_null($identifier)) {
+        if (! is_null($identifier)) {
             $this->setIdentifier($identifier);
         }
 

--- a/src/GoogleOauth.php
+++ b/src/GoogleOauth.php
@@ -46,10 +46,10 @@ class GoogleOauth
     /**
      * Get access token.
      *
-     * @param null $identifier
+     * @param string|null $identifier
      * @return AccessToken
      */
-    public function accessToken($identifier = null): AccessToken
+    public function accessToken(?string $identifier = null): AccessToken
     {
         // Set identifier on the fly.
         if (! is_null($identifier)) {
@@ -91,10 +91,10 @@ class GoogleOauth
     }
 
     /**
-     * @param null $refreshToken
+     * @param string|null $refreshToken
      * @return AccessToken
      */
-    public function refreshAccessToken($refreshToken = null): AccessToken
+    public function refreshAccessToken(?string $refreshToken = null): AccessToken
     {
         if (is_null($refreshToken)) {
             $refreshToken = $this->accessToken()->getRefreshToken();

--- a/src/GoogleOauth.php
+++ b/src/GoogleOauth.php
@@ -1,0 +1,180 @@
+<?php namespace Tipoff\GoogleApi;
+
+use Google_Client;
+use Illuminate\Support\Facades\Route;
+use Tipoff\GoogleApi\Contracts\GoogleOauthDriver;
+use Tipoff\GoogleApi\DataTransferObjects\AccessToken;
+
+class GoogleOauth
+{
+    protected Google_Client $googleClient;
+
+    protected string $identifier = '';
+
+    public function __construct(Google_Client $googleClient, array $config)
+    {
+        $this->googleClient = $googleClient;
+        $this->googleClient->setClientId($config['client_id']);
+        $this->googleClient->setClientSecret($config['client_secret']);
+        $this->googleClient->setRedirectUri($config['redirect_uri']);
+        $this->googleClient->setState($config['state']);
+        $this->googleClient->setAccessType('offline');
+    }
+
+    /**
+     * @param string $identifier
+     * @return $this
+     */
+    public function setIdentifier(string $identifier): self
+    {
+        $this->identifier = $identifier;
+
+        return $this;
+    }
+
+    /**
+     * @param array $scopes
+     * @return $this
+     */
+    public function setScopes(array $scopes): self
+    {
+        $this->googleClient->setScopes($scopes);
+
+        return $this;
+    }
+
+    /**
+     * Get access token.
+     *
+     * @param null $identifier
+     * @return AccessToken
+     */
+    public function accessToken($identifier = null): AccessToken
+    {
+        // Set identifier on the fly.
+        if (!is_null($identifier)) {
+            $this->setIdentifier($identifier);
+        }
+
+        $accessToken = $this->readAccessToken();
+
+        // Refresh access token if it has expired.
+        if ($accessToken->hasExpired()) {
+            $accessToken = $this->refreshAccessToken($accessToken->getRefreshToken());
+        }
+
+        return $accessToken;
+    }
+
+    /**
+     * @return AccessToken
+     * @throws \Exception
+     */
+    public function makeAccessToken(): AccessToken
+    {
+        $authCode = request()->get('code');
+
+        if (empty($authCode)) {
+            throw new \Exception('Cannot get the auth code from Google');
+        }
+
+        $accessToken = $this->googleClient->fetchAccessTokenWithAuthCode($authCode);
+
+        // Set identifier before calling saveAccessToken
+        $this->setIdentifier(session('google_oauth_identifier'));
+
+        request()->session()->forget('google_oauth_identifier');
+
+        $this->saveAccessToken($accessToken);
+
+        return new AccessToken($accessToken);
+    }
+
+    /**
+     * @param null $refreshToken
+     * @return AccessToken
+     */
+    public function refreshAccessToken($refreshToken = null): AccessToken
+    {
+        if (is_null($refreshToken)) {
+            $refreshToken = $this->accessToken()->getRefreshToken();
+        }
+
+        $this->googleClient->fetchAccessTokenWithRefreshToken($refreshToken);
+
+        $token = $this->googleClient->getAccessToken();
+
+        $this->saveAccessToken($token);
+
+        return new AccessToken($token);
+    }
+
+    /**
+     * @return AccessToken
+     */
+    public function readAccessToken(): AccessToken
+    {
+        return $this->getGoogleOauthDriver()->readAccessToken($this->identifier);
+    }
+
+    /**
+     * @return void
+     */
+    public function flushAccessToken()
+    {
+        $this->getGoogleOauthDriver()->flushAccessToken($this->identifier);
+    }
+
+    /**
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function redirect(?string $identifier = null, ?string $homeUrl = '/')
+    {
+        // These data can be pulled in callback method.
+        session(['google_oauth_identifier' => $identifier ?? '']);
+        session(['google_oauth_home_url' => $homeUrl]);
+
+        return redirect()->to($this->getAuthUrl());
+    }
+
+    /**
+     * Gets the URL to authorize the user
+     *
+     * @return string
+     */
+    public function getAuthUrl(): string
+    {
+        return $this->googleClient->createAuthUrl();
+    }
+
+    /**
+     * Alias of "googleOauth" route marco.
+     *
+     * @return mixed
+     */
+    public function routes()
+    {
+        return Route::googleOauth();
+    }
+
+    /**
+     * Register a Google Oauth driver class.
+     *
+     * @param string $class
+     * @return void
+     */
+    public function useDriver(string $class)
+    {
+        app()->singleton(GoogleOauthDriver::class, $class);
+    }
+
+    protected function saveAccessToken(array $accessToken)
+    {
+        $this->getGoogleOauthDriver()->saveAccessToken($this->identifier, $accessToken);
+    }
+
+    protected function getGoogleOauthDriver(): GoogleOauthDriver
+    {
+        return app(GoogleOauthDriver::class);
+    }
+}

--- a/src/Http/Controllers/GoogleOauthController.php
+++ b/src/Http/Controllers/GoogleOauthController.php
@@ -1,0 +1,34 @@
+<?php namespace Tipoff\GoogleApi\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Tipoff\GoogleApi\Facades\GoogleOauth;
+
+class GoogleOauthController extends Controller
+{
+    public function redirect(Request $request)
+    {
+        return GoogleOauth::setScopes($request->get('scopes'))->redirect(
+            $request->get('identifier'),
+            $request->get('home_url')
+        );
+    }
+
+    public function handleCallback(Request $request)
+    {
+        GoogleOauth::makeAccessToken();
+
+        $homeUrl = session('google_oauth_home_url', '/');
+
+        $request->session()->forget('google_oauth_home_url');
+
+        return redirect()->to($homeUrl);
+    }
+
+    public function logout()
+    {
+        GoogleOauth::flushAccessToken();
+
+        return redirect()->back();
+    }
+}

--- a/src/Models/Key.php
+++ b/src/Models/Key.php
@@ -16,7 +16,7 @@ class Key extends BaseModel
     use HasPackageFactory;
 
     protected $casts = [
-        'value' => 'array'
+        'value' => 'array',
     ];
 
     public function gmb_accounts()

--- a/src/Models/Key.php
+++ b/src/Models/Key.php
@@ -15,7 +15,9 @@ class Key extends BaseModel
     use HasUpdater;
     use HasPackageFactory;
 
-    protected $casts = [];
+    protected $casts = [
+        'value' => 'array'
+    ];
 
     public function gmb_accounts()
     {


### PR DESCRIPTION
## What changed?

I added Google Oauth flow to this package, so users can authorize our app to get the access token from their Google account. The access token can be saved under `Key Eloquent Model` or `JSON file`.

I also changed a lot of things in the `GoogleApiServiceProvider`. Below is why I did that:

Currently, we are running a query to find the Key model and call the Google Service to check if the access token has expired, then refresh it and update it back to the database. In my opnion,  this is an expensive cost. We have to repeat those steps on every request even we don't use any Google services on that route. If Google Service is slow, it also slows down our app.

We better have each Google service in its own package. That means this `laravel-google-api` package will take responsibility for getting and saving the access token. Services package will take that access token and expose nice API methods for us.

For instance, when working on the SEO package, I installed the `laravel-google-api` to get the access token and `laravel-google-console` to check the keyword volumes.

```
// Get access token from Google Oauth package.
$accessToken = GoogleOauth::accessToken('google-console');

// Check keyword volumes
GoogleConsole::setAccessToken($accessToken)->checkKeywordVolumes();
```

<img width="643" alt="Screen Shot 2021-04-21 at 12 26 09 AM" src="https://user-images.githubusercontent.com/6707194/115513665-2ce4ea00-a238-11eb-8fe1-21672595f314.png">

Moreover, if doing this way, we not only use our services package, but also we can use 3rd packages. Something like this: https://github.com/schulzefelix/laravel-search-console

## Usage

### Authorization

To set up the Google Oauth flow, we just add `GoogleOauth::routes()` from GoogleOauth Facade in `web.php`

That will create 3 routes:

```
Route::group([
    'prefix'     => $prefix,
    'middleware' => $middleware,
], function () {
    Route::get('oauth', [GoogleOauthController::class, 'redirect'])->name('google-oauth.connect');
    Route::get('callback', [GoogleOauthController::class, 'handleCallback'])->name('google-oauth.callback');
    Route::get('logout', [GoogleOauthController::class, 'logout'])->name('google-oauth.logout');
});
```

We can custom the `$prefix` and `$middleware` like this: 

`GoogleOauth::routes('customer-prefiix', ['web', 'nova', 'api']);`.

Then create an anchor or button in the front-end.

```
$url = route('google-oauth.connect', [
    'identifier' => 'google-console', // The unique key for each service package.
    'home_url'   => url('google-oauth/get'), // The url you want to redirect back after the Oauth flow done.
    'scopes'     => [
        Google_Service_SearchConsole::WEBMASTERS_READONLY
    ] // Array of scopes that we want to request from user.
]);

return '<a href="' . $url . '">Connect to Google</a>';
```

<img width="154" alt="Screen Shot 2021-04-21 at 12 35 40 AM" src="https://user-images.githubusercontent.com/6707194/115514971-83065d00-a239-11eb-9ffa-3471134d0c9a.png">

### Get the access token

```
$accessToken = GoogleOauth::accessToken('google-console');
```

or 

```
$accessToken = GoogleOauth::setIdentifier('google-console')->accessToken();
```

`Identifier` is a unique key for each service package.

The `accessToken` method will refresh the access token automatically if it has expired.

```
$accessToken->getAccessToken(); // Return a string of access token.
$accessToken->getRefreshToken(); // Return refresh token.
$accessToken->hasExpires(); // Check if the access token has expired or not.
```

## Google Oauth Drivers

Currently, this package supports 2 drivers which are:

- `JsonDriver`: Saving and getting access token via a JSON file.
- `KeyEloquentDriver`: Saving and getting access token via the Key model.

The package uses `JsonDriver` by default, we can override it by adding this in the `boot` method of `AppServiceProvider`

```
public function boot()
{
    GoogleOauth::useDriver(KeyEloquentDriver::class);
}
```

We also can write a custom driver. The custom driver class must implement `GoogleOauthDriver` interface and use the above `useDriver` method to register the customer driver.

<img width="819" alt="Screen Shot 2021-04-21 at 12 44 50 AM" src="https://user-images.githubusercontent.com/6707194/115516258-c90ff080-a23a-11eb-8792-510d43bf1113.png">