### PR TITLE
Add Google Services

### DIFF
--- a/config/google-api.php
+++ b/config/google-api.php
@@ -15,8 +15,8 @@ return [
         'search-console'    => [
             'status' => Tipoff\GoogleApi\GoogleServiceStatus::ENABLED,
             'scopes' => [
-                Google_Service_SearchConsole::WEBMASTERS_READONLY,
-                //Google_Service_SearchConsole::WEBMASTERS // Read and write
+                'https://www.googleapis.com/auth/webmasters',
+                'https://www.googleapis.com/auth/webmasters.readonly'
             ]
         ],
         'my-business'       => [

--- a/config/google-api.php
+++ b/config/google-api.php
@@ -7,7 +7,65 @@ return [
 
     'client_secret' => env('GOOGLE_CLIENT_SECRET'),
 
-    'redirect_uri' => env('GOOGLE_REDIRECT_URI', '/'),
+    'redirect_uri' => env('GOOGLE_REDIRECT_URI', url('/')),
 
     'state' => null,
+
+    'services' => [
+        'search-console'    => [
+            'status' => Tipoff\GoogleApi\GoogleServiceStatus::ENABLED,
+            'scopes' => [
+                Google_Service_SearchConsole::WEBMASTERS_READONLY,
+                //Google_Service_SearchConsole::WEBMASTERS // Read and write
+            ]
+        ],
+        'my-business'       => [
+            'status' => Tipoff\GoogleApi\GoogleServiceStatus::ENABLED,
+            'scopes' => [
+                'https://www.googleapis.com/auth/business.manage'
+            ]
+        ],
+        'youtube'           => [
+            'status' => Tipoff\GoogleApi\GoogleServiceStatus::ENABLED,
+            'scopes' => [
+                Google_Service_YouTube::YOUTUBE,
+                //Google_Service_YouTube::YOUTUBE_CHANNEL_MEMBERSHIPS_CREATOR,
+                //Google_Service_YouTube::YOUTUBE_FORCE_SSL,
+                //Google_Service_YouTube::YOUTUBE_READONLY,
+                //Google_Service_YouTube::YOUTUBE_UPLOAD,
+                //Google_Service_YouTube::YOUTUBEPARTNER,
+                //Google_Service_YouTube::YOUTUBEPARTNER_CHANNEL_AUDIT,
+            ]
+        ],
+        'youtube-analytics' => [
+            'status' => Tipoff\GoogleApi\GoogleServiceStatus::ENABLED,
+            'scopes' => [
+                Google_Service_Analytics::ANALYTICS,
+                //Google_Service_Analytics::ANALYTICS_EDIT,
+                //Google_Service_Analytics::ANALYTICS_MANAGE_USERS,
+                //Google_Service_Analytics::ANALYTICS_MANAGE_USERS_READONLY,
+                //Google_Service_Analytics::ANALYTICS_PROVISION,
+                //Google_Service_Analytics::ANALYTICS_READONLY,
+                //Google_Service_Analytics::ANALYTICS_USER_DELETION,
+            ]
+        ],
+        'analytics'         => [
+            'status' => Tipoff\GoogleApi\GoogleServiceStatus::ENABLED,
+            'scopes' => [
+                Google_Service_Analytics::ANALYTICS,
+                //Google_Service_Analytics::ANALYTICS_EDIT,
+                //Google_Service_Analytics::ANALYTICS_MANAGE_USERS,
+                //Google_Service_Analytics::ANALYTICS_MANAGE_USERS_READONLY,
+                //Google_Service_Analytics::ANALYTICS_PROVISION,
+                //Google_Service_Analytics::ANALYTICS_READONLY,
+                //Google_Service_Analytics::ANALYTICS_USER_DELETION,
+            ]
+        ],
+        'places'            => [
+            'status'     => Tipoff\GoogleApi\GoogleServiceStatus::ENABLED,
+            'key'        => env('GOOGLE_PLACES_API_KEY'),
+            'verify_ssl' => env('GOOGLE_PLACES_API_SSL', true),
+            'headers'    => env('GOOGLE_PLACES_API_HEADERS', []),
+        ]
+    ]
 ];

--- a/src/GoogleApiServiceProvider.php
+++ b/src/GoogleApiServiceProvider.php
@@ -20,7 +20,7 @@ class GoogleApiServiceProvider extends TipoffServiceProvider
     {
         $package
             ->hasPolicies([
-                Key::class => KeyPolicy::class,
+                Key::class        => KeyPolicy::class,
                 GmbAccount::class => GmbAccountPolicy::class,
             ])
             ->hasNovaResources([
@@ -45,6 +45,10 @@ class GoogleApiServiceProvider extends TipoffServiceProvider
 
         $this->app->bind('google-oauth', function ($app) {
             return new GoogleOauth(new Google_Client, $app['config']['google-api']);
+        });
+
+        $this->app->bind(GoogleServices::class, function () {
+            return new GoogleServices(new Google_Client);
         });
     }
 }

--- a/src/GoogleApiServiceProvider.php
+++ b/src/GoogleApiServiceProvider.php
@@ -20,7 +20,7 @@ class GoogleApiServiceProvider extends TipoffServiceProvider
     {
         $package
             ->hasPolicies([
-                Key::class        => KeyPolicy::class,
+                Key::class => KeyPolicy::class,
                 GmbAccount::class => GmbAccountPolicy::class,
             ])
             ->hasNovaResources([

--- a/src/GoogleServiceStatus.php
+++ b/src/GoogleServiceStatus.php
@@ -1,0 +1,7 @@
+<?php namespace Tipoff\GoogleApi;
+
+class GoogleServiceStatus
+{
+    const ENABLED = 'enabled';
+    const DISABLED = 'disabled';
+}

--- a/src/GoogleServices.php
+++ b/src/GoogleServices.php
@@ -1,0 +1,121 @@
+<?php namespace Tipoff\GoogleApi;
+
+use Google_Client;
+use Google_Service_Analytics;
+use Google_Service_MyBusiness;
+use Google_Service_SearchConsole;
+use Google_Service_YouTube;
+use Google_Service_YouTubeAnalytics;
+use Illuminate\Support\Collection;
+use SKAgarwal\GoogleApi\PlacesApi;
+use Tipoff\GoogleApi\DataTransferObjects\AccessToken;
+
+class GoogleServices
+{
+    private Google_Client $googleClient;
+
+    public function __construct(Google_Client $googleClient)
+    {
+        $this->googleClient = $googleClient;
+    }
+
+    /**
+     * Set access token before access the services.
+     *
+     * @param $accessToken
+     * @return $this
+     */
+    public function setAccessToken($accessToken): self
+    {
+        if ($accessToken instanceof AccessToken) {
+            $accessToken = $accessToken->getAccessToken();
+        }
+
+        $this->googleClient->setAccessToken($accessToken);
+
+        return $this;
+    }
+
+    /**
+     * Get enabled services in google-api config file.
+     *
+     * @return Collection
+     */
+    public function availableServices(): Collection
+    {
+        $allServices = collect(config('google-api.services'));
+
+        return $allServices->where('status', GoogleServiceStatus::ENABLED);
+    }
+
+    /**
+     * Get all needed scopes from enabled services.
+     *
+     * @return array
+     */
+    public function scopes(): array
+    {
+        return $this->availableServices()->pluck('scopes')
+            ->filter()
+            ->flatten()
+            ->all();
+    }
+
+    public function searchConsole(): Google_Service_SearchConsole
+    {
+        $this->ensureServiceEnabled('search-console');
+
+        return new Google_Service_SearchConsole($this->googleClient);
+    }
+
+    public function myBusiness(): Google_Service_MyBusiness
+    {
+        $this->ensureServiceEnabled('my-business');
+
+        return new Google_Service_MyBusiness($this->googleClient);
+    }
+
+    public function youtube(): Google_Service_YouTube
+    {
+        $this->ensureServiceEnabled('youtube');
+
+        return new Google_Service_YouTube($this->googleClient);
+    }
+
+    public function youtubeAnalytics(): Google_Service_YouTubeAnalytics
+    {
+        $this->ensureServiceEnabled('youtube-analytics');
+
+        return new Google_Service_YouTubeAnalytics($this->googleClient);
+    }
+
+    public function analytics(): Google_Service_Analytics
+    {
+        $this->ensureServiceEnabled('analytics');
+
+        return new Google_Service_Analytics($this->googleClient);
+    }
+
+    public function places(): PlacesApi
+    {
+        $this->ensureServiceEnabled('places');
+
+        /**
+         * @psalm-suppress InvalidArgument
+         */
+        return new PlacesApi(
+            config('google-api.services.places.key'),
+            config('google-api.services.places.verify_ssl'),
+            config('google-api.services.places.headers')
+        );
+    }
+
+    protected function ensureServiceEnabled(string $serviceKey)
+    {
+        $serviceStatus = config("google-api.services.$serviceKey.status", GoogleServiceStatus::DISABLED);
+
+        if ($serviceStatus === GoogleServiceStatus::DISABLED) {
+            throw new \Exception("Service $serviceKey is not enabled.");
+        }
+    }
+}

--- a/src/Http/Controllers/GoogleOauthController.php
+++ b/src/Http/Controllers/GoogleOauthController.php
@@ -3,12 +3,15 @@
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Tipoff\GoogleApi\Facades\GoogleOauth;
+use Tipoff\GoogleApi\GoogleServices;
 
 class GoogleOauthController extends Controller
 {
     public function redirect(Request $request)
     {
-        return GoogleOauth::setScopes($request->get('scopes'))->redirect(
+        $scopes = $request->get('scopes', app(GoogleServices::class)->scopes());
+
+        return GoogleOauth::setScopes($scopes)->redirect(
             $request->get('identifier'),
             $request->get('home_url')
         );

--- a/tests/Unit/Services/GoogleServicesTest.php
+++ b/tests/Unit/Services/GoogleServicesTest.php
@@ -29,7 +29,7 @@ class GoogleServicesTest extends TestCase
 
         $this->fakeToken = [
             'access_token' => 'mock-access-token',
-            'expires_in' => time(),
+            'expires_in' => now()->addDay()->timestamp,
             'scope' => 'https://www.googleapis.com/auth/business.manage',
             'token_type' => 'Bearer',
             'created' => time(),

--- a/tests/Unit/Services/GoogleServicesTest.php
+++ b/tests/Unit/Services/GoogleServicesTest.php
@@ -28,12 +28,12 @@ class GoogleServicesTest extends TestCase
         parent::setUp();
 
         $this->fakeToken = [
-            'access_token'  => 'mock-access-token',
-            'expires_in'    => time(),
-            'scope'         => 'https://www.googleapis.com/auth/business.manage',
-            'token_type'    => 'Bearer',
-            'created'       => time(),
-            'refresh_token' => 'mock-refresh-token'
+            'access_token' => 'mock-access-token',
+            'expires_in' => time(),
+            'scope' => 'https://www.googleapis.com/auth/business.manage',
+            'token_type' => 'Bearer',
+            'created' => time(),
+            'refresh_token' => 'mock-refresh-token',
         ];
 
         $this->googleServices = app(GoogleServices::class);
@@ -61,7 +61,7 @@ class GoogleServicesTest extends TestCase
         Key::firstOrCreate(
             ['slug' => $serviceName],
             [
-                'value'      => $this->fakeToken,
+                'value' => $this->fakeToken,
                 'creator_id' => randomOrCreate(app('user')),
                 'updater_id' => randomOrCreate(app('user')),
             ]

--- a/tests/Unit/Services/GoogleServicesTest.php
+++ b/tests/Unit/Services/GoogleServicesTest.php
@@ -8,6 +8,10 @@ use Google_Service_YouTube;
 use Google_Service_YouTubeAnalytics;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use SKAgarwal\GoogleApi\PlacesApi;
+use Tipoff\GoogleApi\Drivers\KeyEloquentDriver;
+use Tipoff\GoogleApi\Facades\GoogleOauth;
+use Tipoff\GoogleApi\GoogleServices;
+use Tipoff\GoogleApi\GoogleServiceStatus;
 use Tipoff\GoogleApi\Models\Key;
 use Tipoff\GoogleApi\Tests\TestCase;
 
@@ -15,31 +19,35 @@ class GoogleServicesTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected string $fakeJsonToken;
+    protected array $fakeToken;
+
+    protected GoogleServices $googleServices;
 
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->fakeJsonToken = '{"access_token":"mock-access-token","expires_in":3599,"scope":"https:\/\/www.googleapis.com\/auth\/business.manage","token_type":"Bearer","created":'.time().',"refresh_token":"mock-refresh-token"}';
+        $this->fakeToken = [
+            'access_token'  => 'mock-access-token',
+            'expires_in'    => time(),
+            'scope'         => 'https://www.googleapis.com/auth/business.manage',
+            'token_type'    => 'Bearer',
+            'created'       => time(),
+            'refresh_token' => 'mock-refresh-token'
+        ];
+
+        $this->googleServices = app(GoogleServices::class);
+
+        GoogleOauth::useDriver(KeyEloquentDriver::class);
 
         // Because of the order in which Testbench loads things, we don't
         // have access to our .env.test variables when the config is initially
         // set. Override the config settings here so that we can test properly.
         if (file_exists(dirname(__DIR__) . '/../../.env.test')) {
-            $dotenv = \Dotenv\Dotenv::createImmutable(__DIR__.'/../../../', '.env.test');
+            $dotenv = \Dotenv\Dotenv::createImmutable(__DIR__ . '/../../../', '.env.test');
             $dotenv->load();
 
-            config(['google-api' => include(realpath(__DIR__.'/../../../config/google-api.php'))]);
-
-            Key::updateOrCreate(
-                ['slug' => config('google-api.my-business.access-token-slug')],
-                [
-                    'value' => env('GOOGLE_MYBUSINESS_ACCESS_TOKEN_VALUE'),
-                    'creator_id' => randomOrCreate(app('user')),
-                    'updater_id' => randomOrCreate(app('user')),
-                ]
-            );
+            config(['google-api' => include(realpath(__DIR__ . '/../../../config/google-api.php'))]);
         }
     }
 
@@ -48,12 +56,12 @@ class GoogleServicesTest extends TestCase
      * file, create a mock one here that the Google client will accept
      * for creating the client.
      */
-    protected function mockJsonToken(string $serviceName) : void
+    protected function mockJsonToken(string $serviceName): void
     {
         Key::firstOrCreate(
-            ['slug' => config("google-api.$serviceName.access-token-slug")],
+            ['slug' => $serviceName],
             [
-                'value' => $this->fakeJsonToken,
+                'value'      => $this->fakeToken,
                 'creator_id' => randomOrCreate(app('user')),
                 'updater_id' => randomOrCreate(app('user')),
             ]
@@ -61,11 +69,25 @@ class GoogleServicesTest extends TestCase
     }
 
     /** @test */
+    public function it_builds_the_Google_Search_Console_service()
+    {
+        $this->mockJsonToken('search-console');
+
+        $accessToken = GoogleOauth::accessToken('search-console');
+
+        $service = $this->googleServices->setAccessToken($accessToken)->searchConsole();
+
+        $this->assertInstanceOf(\Google_Service_SearchConsole::class, $service);
+    }
+
+    /** @test */
     public function it_builds_the_Google_My_Business_service()
     {
         $this->mockJsonToken('my-business');
 
-        $service = app()->make(Google_Service_MyBusiness::class);
+        $accessToken = GoogleOauth::accessToken('my-business');
+
+        $service = $this->googleServices->setAccessToken($accessToken)->myBusiness();
 
         $this->assertInstanceOf(Google_Service_MyBusiness::class, $service);
     }
@@ -75,7 +97,9 @@ class GoogleServicesTest extends TestCase
     {
         $this->mockJsonToken('youtube');
 
-        $service = app()->make(Google_Service_YouTube::class);
+        $accessToken = GoogleOauth::accessToken('youtube');
+
+        $service = $this->googleServices->setAccessToken($accessToken)->youtube();
 
         $this->assertInstanceOf(Google_Service_YouTube::class, $service);
     }
@@ -85,7 +109,9 @@ class GoogleServicesTest extends TestCase
     {
         $this->mockJsonToken('youtube-analytics');
 
-        $service = app()->make(Google_Service_YouTubeAnalytics::class);
+        $accessToken = GoogleOauth::accessToken('youtube-analytics');
+
+        $service = $this->googleServices->setAccessToken($accessToken)->youtubeAnalytics();
 
         $this->assertInstanceOf(Google_Service_YouTubeAnalytics::class, $service);
     }
@@ -95,7 +121,9 @@ class GoogleServicesTest extends TestCase
     {
         $this->mockJsonToken('analytics');
 
-        $service = app()->make(Google_Service_Analytics::class);
+        $accessToken = GoogleOauth::accessToken('analytics');
+
+        $service = $this->googleServices->setAccessToken($accessToken)->analytics();
 
         $this->assertInstanceOf(Google_Service_Analytics::class, $service);
     }
@@ -103,8 +131,24 @@ class GoogleServicesTest extends TestCase
     /** @test */
     public function it_builds_the_Google_Places_service()
     {
-        $service = app()->make(PlacesApi::class);
+        $service = $this->googleServices->places();
 
         $this->assertInstanceOf(PlacesApi::class, $service);
+    }
+
+    public function test_cannot_access_service_if_it_disabled()
+    {
+        config(['google-api.services.places.status' => GoogleServiceStatus::DISABLED]);
+
+        $this->expectException(\Exception::class);
+
+        $this->googleServices->places();
+    }
+
+    public function test_can_get_scopes()
+    {
+        config(['google-api.services.analytics.scopes' => Google_Service_Analytics::ANALYTICS]);
+
+        $this->assertTrue(in_array(Google_Service_Analytics::ANALYTICS, $this->googleServices->scopes()));
     }
 }


### PR DESCRIPTION
## Google Services

Per Josh's discussion at https://github.com/tipoff/laravel-google-api/pull/36#issuecomment-824230819, I added Google Services into this package and add the ability to enable/disable service.

We will access those services like this:

```
// Get access token.
$accessToken = GoogleOauth::accessToken('search-console');

// Set access token.
$googleServices = app(GoogleServices::class)->setAccessToken($accessToken);

// Access services.
$searchConsole = $googleServices->searchConsole();
$myBusiness = $googleServices->myBusiness();
$youtube = $googleServices->youtube();
$youtubeAnalytics = $googleServices->youtubeAnalytics();
$analytics = $googleServices->analytics();
$place = $googleServices->places();
```

You can enable/disable service via the `google-api` config file.

<img width="731" alt="Screen Shot 2021-04-22 at 6 38 50 PM" src="https://user-images.githubusercontent.com/6707194/115805520-fcb55c80-a399-11eb-93f9-e336f25bd2ab.png">

**Get all available services (enabled services):**

`app(GoogleServices::class)->availableServices()`

**Get needed scopes of the enabled services:**

`app(GoogleServices::class)->scopes()`

**Notice:** If you try to access a disabled service, it will throw an exception to tell that service is disabled.

## Google Oauth

Make `scopes` key is skippable when creating the URL for Google Oauth.


**Before this PR:**

```
route('google-oauth.connect', [
    'identifier' => 'google-console',
    'home_url'   => url('google-oauth/get'),
    'scopes'     => [
        Google_Service_SearchConsole::WEBMASTERS_READONLY
    ]
]);
```

**After this PR:**
```
route('google-oauth.connect', [
    'identifier' => 'google-console',
    'home_url'   => url('google-oauth/get')
]);
```

Instead of getting scopes from `scope` key, it will get scopes from `google-api` config file automatically via:

`$scopes = $request->get('scopes', app(GoogleServices::class)->scopes());`

## Scopes

@drewroberts I listed all the scopes for all services in the `google-api` config file, but I don't know what scopes we gonna use so I just keep the basic one for each service. You can go to that file and enable them.

<img width="870" alt="Screen Shot 2021-04-22 at 6 46 48 PM" src="https://user-images.githubusercontent.com/6707194/115806167-199e5f80-a39b-11eb-9b85-e2c926c3bf53.png">