### PR TITLE
Makes use of a third-party wrapper to access the Google Search Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,31 +58,25 @@ The models also have [Laravel Nova resources](https://nova.laravel.com/docs/3.0/
 ## Usage
 
 ```
-// Instantiate the Google My Business Client.
-$gmbClient = app()->make(\Google_Service_MyBusiness::class);
+// Get access token.
+$accessToken = GoogleOauth::accessToken('search-console');
 
-// Use the client to act on the API.
-$gmblocations = $gmbClient->accounts_locations
-    ->get('accounts/{account-id}/locations')
-    ->toSimpleObject()
-    ->locations;
+// Set access token.
+$googleServices = app(GoogleServices::class)->setAccessToken($accessToken);
 
-// Instantiate other services similarly:
-// Google Analytics
-$client = app()->make(\Google_Service_Analytics::class);
-
-// YouTube Data Service
-$client = app()->make(\Google_Service_YouTube::class);
-
-// YouTube Analytics Service
-$client = app()->make(\Google_Service_YouTubeAnalytics::class);
-
-// Google Places API
-$client = app()->make(\SKAgarwal\GoogleApi\PlacesApi::class);
+// Access services.
+$searchConsole = $googleServices->searchConsole();
+$myBusiness = $googleServices->myBusiness();
+$youtube = $googleServices->youtube();
+$youtubeAnalytics = $googleServices->youtubeAnalytics();
+$analytics = $googleServices->analytics();
+$place = $googleServices->places();
 ```
 
-**Note:** The Google Places service makes use of a third-party wrapper to access the Places API.
+**Note:** 
+- The Google Places service makes use of a third-party wrapper to access the Places API.
 Documentation on available methods for it is available [here](https://github.com/SachinAgarwal1337/google-places-api/#available-methods).
+- The Google Search Console service makes use of a third-party wrapper to access the Laravel Search Console. Documentation on available methods for it is available [here](https://github.com/schulzefelix/laravel-search-console).
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "google/apiclient": "^2.7",
+        "schulzefelix/laravel-search-console": "^1.7",
         "skagarwal/google-places-api": "^1.7",
         "spatie/data-transfer-object": "^2.8",
         "spatie/valuestore": "^1.2",

--- a/src/GoogleServices.php
+++ b/src/GoogleServices.php
@@ -3,10 +3,11 @@
 use Google_Client;
 use Google_Service_Analytics;
 use Google_Service_MyBusiness;
-use Google_Service_SearchConsole;
 use Google_Service_YouTube;
 use Google_Service_YouTubeAnalytics;
 use Illuminate\Support\Collection;
+use SchulzeFelix\SearchConsole\SearchConsole;
+use SchulzeFelix\SearchConsole\SearchConsoleClient;
 use SKAgarwal\GoogleApi\PlacesApi;
 use Tipoff\GoogleApi\DataTransferObjects\AccessToken;
 
@@ -61,11 +62,12 @@ class GoogleServices
             ->all();
     }
 
-    public function searchConsole(): Google_Service_SearchConsole
+    public function searchConsole(): SearchConsole
     {
         $this->ensureServiceEnabled('search-console');
 
-        return new Google_Service_SearchConsole($this->googleClient);
+        return (new SearchConsole(app(SearchConsoleClient::class)))
+            ->setAccessToken($this->googleClient->getAccessToken());
     }
 
     public function myBusiness(): Google_Service_MyBusiness

--- a/tests/Unit/Services/GoogleServicesTest.php
+++ b/tests/Unit/Services/GoogleServicesTest.php
@@ -7,6 +7,7 @@ use Google_Service_MyBusiness;
 use Google_Service_YouTube;
 use Google_Service_YouTubeAnalytics;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use SchulzeFelix\SearchConsole\SearchConsole;
 use SKAgarwal\GoogleApi\PlacesApi;
 use Tipoff\GoogleApi\Drivers\KeyEloquentDriver;
 use Tipoff\GoogleApi\Facades\GoogleOauth;
@@ -77,7 +78,7 @@ class GoogleServicesTest extends TestCase
 
         $service = $this->googleServices->setAccessToken($accessToken)->searchConsole();
 
-        $this->assertInstanceOf(\Google_Service_SearchConsole::class, $service);
+        $this->assertInstanceOf(SearchConsole::class, $service);
     }
 
     /** @test */


### PR DESCRIPTION
The Google Search Console service makes use of a third-party wrapper to access the Laravel Search Console. Documentation on available methods for it is available [here](https://github.com/schulzefelix/laravel-search-console).