### PR TITLE
Argument 2 passed to Illuminate\Routing\UrlGenerator::__construct() must be an instance of Illuminate\Http\Request

### DIFF
--- a/config/google-api.php
+++ b/config/google-api.php
@@ -7,7 +7,7 @@ return [
 
     'client_secret' => env('GOOGLE_CLIENT_SECRET'),
 
-    'redirect_uri' => env('GOOGLE_REDIRECT_URI', url('/')),
+    'redirect_uri' => env('GOOGLE_REDIRECT_URI', '/'),
 
     'state' => null,
 


### PR DESCRIPTION
Got this error when running any commands from the console.

Fixes https://github.com/tipoff/laravel-google-api/issues/41