### PR TITLE
Set Approval Prompt to force to always get the refresh token

### DIFF
--- a/src/GoogleOauth.php
+++ b/src/GoogleOauth.php
@@ -19,6 +19,7 @@ class GoogleOauth
         $this->googleClient->setRedirectUri($config['redirect_uri']);
         $this->googleClient->setState($config['state']);
         $this->googleClient->setAccessType('offline');
+        $this->googleClient->setApprovalPrompt('force');
     }
 
     /**


### PR DESCRIPTION
For some reason, Google doesn't return the refresh_token in the 2nd or further requests. I set Approval Prompt to force to always get the refresh token.